### PR TITLE
Set character encoding to UTF-8 in DockerFile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:14.04
 
+## Set character encoding configuration to UTF-8.
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 RUN apt-get update
 RUN apt-get install -y git
 RUN apt-get install -y vim


### PR DESCRIPTION
We observed ascii-encoding errors created by some comments present in samza source
code(HDFSSystemAdmin, EventHubSystemAdmin, which required utf-8/16 charset) when generating build within the docker container.

To fix ascii encoding errors, set charset configuration to UTF-8 when building docker-image.